### PR TITLE
Add subscriptionId to response body

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     ast (2.4.0)
     coderay (1.1.2)
     diff-lcs (1.3)
-    graphql (1.9.7)
+    graphql (1.9.8)
     jaro_winkler (1.5.3)
     method_source (0.9.2)
     multi_json (1.13.1)

--- a/spec/graphql_helper.rb
+++ b/spec/graphql_helper.rb
@@ -1,0 +1,20 @@
+class HealthResponseType < GraphQL::Schema::Object
+  field :status, String, null: false
+end
+
+class TestQueryType < GraphQL::Schema::Object
+  field :health, HealthResponseType, null: true do
+    description 'Static endpoint used for testing purposes'
+  end
+
+  def health
+    OpenStruct.new(status: :ok)
+  end
+end
+
+class TestSubscription < GraphQL::Schema
+end
+
+class TestSchema < GraphQL::Schema
+  query TestQueryType
+end


### PR DESCRIPTION
Unfortunately Apollo client does't have an access to headers and is not able to use `subscriptionId` from response header.

There is an [alternative solution](https://github.com/apollographql/apollo-feature-requests/issues/93), but it's still  in progress.

This PR adds `subscriptionId` to the response body for subscription queries, so Apollo clients can get `subscriptionId` easily.

Example:

```
# request
subscription messageReceived {
  messageReceived {
    id
  }
}
```

```
# response
{
  "data": {
    "messageReceived": null,
    "subscriptionId": "cdb547d6-9057-4f16-9b4e-12a6dadc0557"
  }
}
```
