### PR TITLE
Respond with HTTP status 400 when passed UTF null byte as part of an input.

### DIFF
--- a/lib/rack_graphql/middleware.rb
+++ b/lib/rack_graphql/middleware.rb
@@ -74,7 +74,10 @@ module RackGraphql
     end
 
     def post_data(env)
-      ::Oj.load(env['rack.input'].gets.to_s)
+      payload = env['rack.input'].read.to_s
+      return nil if payload.index('\u0000')
+
+      ::Oj.load(payload)
     rescue Oj::ParseError
       nil
     end

--- a/spec/rack_graphql/middleware_spec.rb
+++ b/spec/rack_graphql/middleware_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe RackGraphql::Middleware do
     subject { described_class.new(schema: GraphQL::Schema, context_handler: context_handler).call(env) }
 
     let(:context_handler) { ->(env) { { bacon: 'steak', env: env } } }
-    let(:env) { { 'rack.input' => instance_double(Rack::RewindableInput, gets: Oj.dump({})), 'REQUEST_METHOD' => request_method } }
+    let(:env) { { 'rack.input' => instance_double(Rack::RewindableInput, read: Oj.dump({})), 'REQUEST_METHOD' => request_method } }
 
     describe 'non-POST request' do
       let(:request_method) { 'PUT' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,10 @@ class HealthResponseType < GraphQL::Schema::Object
   field :status, String, null: false
 end
 
+class ProductsResponseType < GraphQL::Schema::Object
+  field :products, [String], null: false
+end
+
 class TestQueryType < GraphQL::Schema::Object
   field :health, HealthResponseType, null: true do
     description 'Static endpoint used for testing purposes'
@@ -43,6 +47,17 @@ class TestQueryType < GraphQL::Schema::Object
 
   def health
     HealthResponseBuilder.build
+  end
+
+  field :search, ProductsResponseType, null: true do
+    argument :keyword, String, required: true
+    description 'Endpoint with parameters used for testing purposes'
+  end
+
+  def search(keyword:)
+    OpenStruct.new(
+      products: keyword.empty? ? [] : %w[Toothbrush Soap]
+    )
   end
 end
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Respond with HTTP status 400 when passed UTF null byte as part of an input.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- utf null byte is not an input a typical user would pass. 
- it can create problems downstream (i.e. at AR -> pg gem adapters level) 