### PR TITLE
rescue all exceptions at middleware level only, when set in config to do this.

### DIFF
--- a/lib/rack_graphql.rb
+++ b/lib/rack_graphql.rb
@@ -16,6 +16,12 @@ module RackGraphql
       %w[1 true].include?(ENV['RACK_GRAPHQL_LOG_EXCEPTION_BACKTRACE'].to_s)
     end
 
-    attr_writer :log_exception_backtrace
+    def rescue_exceptions_with_500_json
+      return @rescue_exceptions_with_500_json unless @rescue_exceptions_with_500_json.nil?
+
+      %w[1 true].include?(ENV['RACK_GRAPHQL_RESCUE_EXCEPTIONS'].to_s) || ENV['RACK_GRAPHQL_RESCUE_EXCEPTIONS'].nil?
+    end
+
+    attr_writer :log_exception_backtrace, :rescue_exceptions_with_500_json
   end
 end

--- a/lib/rack_graphql/middleware.rb
+++ b/lib/rack_graphql/middleware.rb
@@ -10,6 +10,7 @@ module RackGraphql
       context_handler: nil,
       logger: nil,
       log_exception_backtrace: RackGraphql.log_exception_backtrace,
+      rescue_exceptions_with_500_json: RackGraphql.rescue_exceptions_with_500_json,
       error_status_code_map: {}
     )
 
@@ -18,6 +19,7 @@ module RackGraphql
       @context_handler = context_handler || ->(_) {}
       @logger = logger
       @log_exception_backtrace = log_exception_backtrace
+      @rescue_exceptions_with_500_json = rescue_exceptions_with_500_json
       @error_status_code_map = error_status_code_map
     end
 
@@ -57,6 +59,8 @@ module RackGraphql
       log(exception_string)
       env[Rack::RACK_ERRORS].puts(exception_string)
       env[Rack::RACK_ERRORS].flush
+      raise unless rescue_exceptions_with_500_json
+
       [
         error_status_code_map[e.class] || DEFAULT_ERROR_STATUS_CODE,
         { 'Content-Type' => 'application/json' },
@@ -68,7 +72,7 @@ module RackGraphql
 
     private
 
-    attr_reader :schema, :app_name, :logger, :context_handler, :log_exception_backtrace, :error_status_code_map
+    attr_reader :schema, :app_name, :logger, :context_handler, :log_exception_backtrace, :rescue_exceptions_with_500_json, :error_status_code_map
 
     def post_request?(env)
       env['REQUEST_METHOD'] == 'POST'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I would like to propose an option for the application which is using the middleware, to choose if it wants to have `StandardError` be rescued or i.e. to handle Exception on the application's side.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It would give more freedom to the services using it on how to rescue Exceptions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
rspec
