### PR TITLE
Extract Middlewares to improve control exception responses

### DIFF
--- a/lib/rack_graphql.rb
+++ b/lib/rack_graphql.rb
@@ -5,6 +5,8 @@ require 'graphql'
 require 'rack_graphql/version'
 require 'rack_graphql/exceptions'
 require 'rack_graphql/health_response_builder'
+require 'rack_graphql/log_errors_middleware'
+require 'rack_graphql/exception_json_response_middleware'
 require 'rack_graphql/middleware'
 require 'rack_graphql/application'
 

--- a/lib/rack_graphql/application.rb
+++ b/lib/rack_graphql/application.rb
@@ -1,5 +1,6 @@
 module RackGraphql
   class Application
+    # rubocop:disable Metrics/ParameterLists
     def self.call(
       schema:,
       app_name: 'rack-graphql-service',
@@ -8,18 +9,30 @@ module RackGraphql
       log_exception_backtrace: RackGraphql.log_exception_backtrace,
       health_route: true,
       health_response_builder: RackGraphql::HealthResponseBuilder,
-      error_status_code_map: {}
+      error_status_code_map: {},
+      error_response_middleware: RackGraphql::ExceptionJSONResponseMiddleware,
+      middlewares: []
     )
+      # rubocop:enable Metrics/ParameterLists
 
       ::Rack::Builder.new do
+        if error_response_middleware
+          use(
+            error_response_middleware,
+            app_name: app_name,
+            error_status_code_map: error_status_code_map,
+            log_exception_backtrace: log_exception_backtrace
+          )
+        end
+        use(::RackGraphql::LogErrorsMiddleware, logger: logger, log_exception_backtrace: log_exception_backtrace)
+        middlewares.each { |middleware| use middleware }
+
         map '/graphql' do
           run RackGraphql::Middleware.new(
             app_name: app_name,
             schema: schema,
             context_handler: context_handler,
             logger: logger,
-            log_exception_backtrace: log_exception_backtrace,
-            error_status_code_map: error_status_code_map,
           )
         end
 

--- a/lib/rack_graphql/exception_json_response_middleware.rb
+++ b/lib/rack_graphql/exception_json_response_middleware.rb
@@ -1,0 +1,42 @@
+module RackGraphql
+  class ExceptionJSONResponseMiddleware
+    DEFAULT_ERROR_STATUS_CODE = 500
+
+    def initialize(app, app_name:, error_status_code_map:, log_exception_backtrace:)
+      @app = app
+      @app_name = app_name
+      @error_status_code_map = error_status_code_map
+      @log_exception_backtrace = log_exception_backtrace
+    end
+
+    def call(env)
+      @app.call(env)
+    rescue AmbiguousParamError
+      [
+        400,
+        { 'Content-Type' => 'application/json' },
+        [Oj.dump({})]
+      ]
+    rescue StandardError, LoadError, SyntaxError => e
+      [
+        error_status_code_map[e.class] || DEFAULT_ERROR_STATUS_CODE,
+        { 'Content-Type' => 'application/json' },
+        [Oj.dump('errors' => [exception_hash(e)])]
+      ]
+    ensure
+      ActiveRecord::Base.clear_active_connections! if defined?(ActiveRecord::Base)
+    end
+
+    private
+
+    attr_reader :app_name, :error_status_code_map, :log_exception_backtrace
+
+    def exception_hash(exception)
+      {
+        'app_name' => app_name,
+        'message' => "#{exception.class}: #{exception.message}",
+        'backtrace' => log_exception_backtrace ? exception.backtrace : "[FILTERED]"
+      }
+    end
+  end
+end

--- a/lib/rack_graphql/log_errors_middleware.rb
+++ b/lib/rack_graphql/log_errors_middleware.rb
@@ -1,0 +1,40 @@
+module RackGraphql
+  # write exception to logs and re-raise error, to pass to next middlewares
+  class LogErrorsMiddleware
+    def initialize(app, logger:, log_exception_backtrace: false)
+      @app = app
+      @logger = logger
+      @log_exception_backtrace = log_exception_backtrace
+    end
+
+    def call(env)
+      @app.call(env)
+    rescue StandardError, LoadError, SyntaxError, AmbiguousParamError => e
+      log_errors(e, env)
+      raise
+    end
+
+    private
+
+    attr_reader :log_exception_backtrace, :logger
+
+    def log_errors(exception, env)
+      exception_string = dump_exception(exception)
+      env[Rack::RACK_ERRORS].puts(exception_string)
+      env[Rack::RACK_ERRORS].flush
+
+      log(exception_string) if logger
+    end
+
+    # Based on https://github.com/rack/rack/blob/master/lib/rack/show_exceptions.rb
+    def dump_exception(exception)
+      string = "#{exception.class}: #{exception.message}\n"
+      string << exception.backtrace.map { |l| "\t#{l}" }.join("\n") if log_exception_backtrace
+      string
+    end
+
+    def log(message)
+      logger.error("[rack-graphql] #{message}")
+    end
+  end
+end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Extracted 2 new middlewares (included by default inside `RackGraphql::Application`) :

    - `LogErrorsMiddleware`  for logging exceptions 
    - `ExceptionJSONResponseMiddleware` for responding with error JSON response in case of exceptions. 

- Allowed injecting other middlewares (i.e. exception catchers, like `Raven::Rack`  etc)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Easier configuration of handling exceptions and error logging

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
rspec
