### PR TITLE
An option to enable / disable map '/' with healthcheck response

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ run RackGraphql::Application.call(
   log_exception_backtrace: !A9n.env.production?,    # optional, `false` default
   # `true` when `RACK_GRAPHQL_LOG_EXCEPTION_BACKTRACE` env var is set to `'1'` or `'true'`
   health_route: true,                               # optional, true by default
+  health_on_root_path: health_route,                # optional, health_route value by default (mind map '/' is covering '/any/path-123') 
   logger: A9n.logger,                               # optional, not set by default
   error_status_code_map: { IamTeapotError => 418 }, # optional
   re_raise_exceptions: true,                        # optional, false by default

--- a/lib/rack_graphql/application.rb
+++ b/lib/rack_graphql/application.rb
@@ -9,6 +9,7 @@ module RackGraphql
       log_exception_backtrace: RackGraphql.log_exception_backtrace,
       health_route: true,
       health_response_builder: RackGraphql::HealthResponseBuilder,
+      root_path_response_builder: RackGraphql::HealthResponseBuilder,
       error_status_code_map: {}
     )
 
@@ -33,9 +34,11 @@ module RackGraphql
           map '/healthz' do
             run ->(env) { health_response_builder.new(app_name: app_name, env: env).build }
           end
+        end
 
+        if root_path_response_builder
           map '/' do
-            run ->(env) { health_response_builder.new(app_name: app_name, env: env).build }
+            run ->(env) { root_path_response_builder.new(app_name: app_name, env: env).build }
           end
         end
       end

--- a/lib/rack_graphql/application.rb
+++ b/lib/rack_graphql/application.rb
@@ -9,7 +9,7 @@ module RackGraphql
       log_exception_backtrace: RackGraphql.log_exception_backtrace,
       health_route: true,
       health_response_builder: RackGraphql::HealthResponseBuilder,
-      root_path_response_builder: RackGraphql::HealthResponseBuilder,
+      health_on_root_path: health_route,
       error_status_code_map: {}
     )
 
@@ -36,9 +36,9 @@ module RackGraphql
           end
         end
 
-        if root_path_response_builder
+        if health_on_root_path
           map '/' do
-            run ->(env) { root_path_response_builder.new(app_name: app_name, env: env).build }
+            run ->(env) { health_response_builder.new(app_name: app_name, env: env).build }
           end
         end
       end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
 - allow passing `health_on_root_path`, to be able to skip healthcheck response on `map '/'` (while keeping gem's `map 'health'` and `map '/healthz'`)
 - backward compatible (taking `health_route` as default value )

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow to skip or overwrite `map '/'`, while still keeping `/health` without too much custom settings.

