### PR TITLE
Fix 14 Dependabot security alerts: update rack to 3.2.6 and json to 2.19.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.18.1)
+    json (2.19.3)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -50,7 +50,7 @@ GEM
       date
       stringio
     racc (1.8.1)
-    rack (3.2.5)
+    rack (3.2.6)
     rack-test (2.2.0)
       rack (>= 1.3)
     rainbow (3.1.1)
@@ -135,4 +135,4 @@ DEPENDENCIES
   standard
 
 BUNDLED WITH
-  4.0.4
+  4.0.9


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description, motivation and context

Updates `rack` and `json` gems in `Gemfile.lock` to resolve all 14 open Dependabot security alerts.

### Changes

| Gem | From | To | Vulnerabilities Fixed |
|-----|------|-----|----------------------|
| `rack` | 3.2.5 | 3.2.6 | 13 CVEs (alerts #1–#13) |
| `json` | 2.18.1 | 2.19.3 | 1 CVE (alert #14) |

### rack 3.2.5 → 3.2.6 (13 alerts)

- **CVE-2026-34835** (MEDIUM): Host allowlist bypass via invalid characters in `Rack::Request`
- **CVE-2026-34831** (MEDIUM): Content-Length mismatch in `Rack::Files` error responses
- **CVE-2026-34830** (MEDIUM): `Rack::Sendfile` regex injection via X-Accel-Mapping
- **HIGH**: Unbounded chunked file uploads via multipart parsing without Content-Length
- **MEDIUM**: Root directory disclosure via unescaped regex in `Rack::Directory`
- **MEDIUM**: Quadratic complexity DoS via wildcard Accept-Encoding header
- **MEDIUM**: Forwarded header semicolon injection (Host/Scheme spoofing)
- **MEDIUM**: CRLF preservation in folded multipart headers
- **LOW**: Greedy multipart boundary parsing (parser differential / WAF bypass)
- **HIGH**: DoS via escape-heavy quoted parameters in multipart headers
- **MEDIUM**: DoS via excessive overlapping byte ranges in multipart
- **HIGH**: `Rack::Static` prefix matching exposes unintended files
- **MEDIUM**: `Rack::Static` header_rules bypass via URL-encoded paths

### json 2.18.1 → 2.19.3 (1 alert)

- **HIGH**: Format string injection vulnerability in Ruby JSON

### Testing

All 26 RSpec examples pass with no failures.

## Related tickets(s), PR(s) or slack message:

SEC-16
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SEC-16](https://linear.app/renofi/issue/SEC-16/dependabot-rack-graphql-14-open-security-alerts)

<div><a href="https://cursor.com/agents/bc-28856519-3fd7-4480-8dc5-1a93cafa63a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28856519-3fd7-4480-8dc5-1a93cafa63a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

